### PR TITLE
Improve math library check

### DIFF
--- a/opus_config.cmake
+++ b/opus_config.cmake
@@ -24,6 +24,10 @@ if(MSVC)
 endif()
 
 set(system_libs "")
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+
+include(CheckLibraryExists)
+check_library_exists(m floor "" HAVE_LIBM)
+if(HAVE_LIBM)
   list(APPEND system_libs m)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES m)
 endif()


### PR DESCRIPTION
* Check if math library is required
* Add math library to `CMAKE_REQUIRED_LIBRARIES` when it is required to allow successful checks of math functions (e.g. without it `check_function_exists(floor HAVE_FLOOR)` will fail)