### PR TITLE
Remove public directory from PRIVATE section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@ target_include_directories(opus
                            PRIVATE $<BUILD_INTERFACE:
                                    ${CMAKE_CURRENT_SOURCE_DIR}/celt
                                    ${CMAKE_CURRENT_SOURCE_DIR}/silk
-                                   >
-                                   $<INSTALL_INTERFACE:include>)
+                                   >)
 target_compile_definitions(opus PRIVATE CUSTOM_MODES OPUS_BUILD)
 
 add_sources_group(opus silk ${silk_sources})


### PR DESCRIPTION
It is already in `PUBLIC` section, so CMake will add it to public dependencies and use it for private build.