### PR TITLE
CMake: Add detection for lrint and lrintf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,11 @@ if(COMPILER_SUPPORT_NEON AND OPUS_USE_NEON)
   endif()
 endif()
 
+target_compile_definitions(opus
+                           PRIVATE
+                           $<$<BOOL:${HAVE_LRINT}>:HAVE_LRINT>
+                           $<$<BOOL:${HAVE_LRINTF}>:HAVE_LRINTF>)
+
 install(TARGETS opus
         EXPORT OpusTargets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/opus_config.cmake
+++ b/opus_config.cmake
@@ -16,6 +16,10 @@ if(HAVE_LIBM)
   list(APPEND OPUS_REQUIRED_LIBRARIES m)
 endif()
 
+include(CheckFunctionExists)
+check_function_exists(lrintf HAVE_LRINTF)
+check_function_exists(lrint HAVE_LRINT)
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i[0-9]86|x86|X86|amd64|AMD64|x86_64)")
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(OPUS_CPU_X64 1)


### PR DESCRIPTION
Add support for detecting the presence of lrint and lrintf. Fixes warnings on ARM (and other platforms without SSE) such as:

<pre>
[143/146] Building C object CMakeFiles/opus.dir/silk/float/pitch_analysis_core_FLP.c.o
In file included from ../silk/float/pitch_analysis_core_FLP.c:35:
In file included from ../silk/float/SigProc_FLP.h:32:
../celt/float_cast.h:129:10: warning: "Don't have the functions lrint() and lrintf ()." [-W#warnings]
        #warning "Don't have the functions lrint() and lrintf ()."
         ^
../celt/float_cast.h:130:10: warning: "Replacing these functions with a standard C cast." [-W#warnings]
        #warning "Replacing these functions with a standard C cast."
         ^
</pre>
