### PR TITLE
cmake/CFeatureCheck.cmake: fix feature tests failing when Opus is a submodule

### DIFF
--- a/cmake/CFeatureCheck.cmake
+++ b/cmake/CFeatureCheck.cmake
@@ -27,7 +27,7 @@ function(c_feature_check FILE)
 
   if (NOT DEFINED COMPILE_${FEATURE})
       message(STATUS "Performing Test ${FEATURE}")
-      try_compile(COMPILE_${FEATURE} ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/${FILE}.c)
+      try_compile(COMPILE_${FEATURE} ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/${FILE}.c)
   endif()
 
   if(COMPILE_${FEATURE})


### PR DESCRIPTION
xiph/opus#182